### PR TITLE
Disable add recipient button when recipe specification is invalid

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -196,11 +196,13 @@ export const Button: FC<ButtonProps> = (props) => {
     loading = false,
     status = "default",
     type = "button",
+    onClick,
     ...rest
   } = props;
 
   return (
     <StyledButton
+      onClick={(e) => !disabled && onClick && onClick(e)}
       $disabled={disabled}
       $kind={kind}
       $status={status}

--- a/src/components/PluginPolicyList.tsx
+++ b/src/components/PluginPolicyList.tsx
@@ -7,42 +7,38 @@ import { PluginPolicyModal } from "components/PluginPolicyModal";
 import { Stack } from "components/Stack";
 import { TrashIcon } from "icons/TrashIcon";
 import { Policy, PolicySchema } from "proto/policy_pb";
-import { RecipeSchema } from "proto/recipe_specification_pb";
 import { FC, useCallback, useEffect, useState } from "react";
 import { toCapitalizeFirst, toNumeralFormat } from "utils/functions";
-import {
-  delPluginPolicy,
-  getPluginPolicies,
-  getRecipeSpecification,
-} from "utils/services/marketplace";
-import { Configuration, Plugin, PluginPolicy } from "utils/types";
+import { delPluginPolicy, getPluginPolicies } from "utils/services/marketplace";
+import { CustomPluginPolicy, CustomRecipeSchema, Plugin } from "utils/types";
 
-interface ParsedPluginPolicy extends PluginPolicy {
-  parsedRecipe: Policy;
+interface PluginPolicyListProps {
+  plugin: Plugin;
+  schema?: CustomRecipeSchema;
 }
 
 interface InitialState {
   loading: boolean;
-  policies: ParsedPluginPolicy[];
-  schema?: Omit<RecipeSchema, "configuration"> & {
-    configuration?: Configuration;
-  };
+  policies: CustomPluginPolicy[];
   totalCount: number;
 }
 
-export const PluginPolicyList: FC<Plugin> = (plugin) => {
+export const PluginPolicyList: FC<PluginPolicyListProps> = ({
+  plugin,
+  schema,
+}) => {
   const initialState: InitialState = {
     loading: true,
     policies: [],
     totalCount: 0,
   };
   const [state, setState] = useState(initialState);
-  const { loading, policies, schema } = state;
+  const { loading, policies } = state;
   const [messageApi, messageHolder] = message.useMessage();
   const [modalAPI, modalHolder] = Modal.useModal();
   const { id } = plugin;
 
-  const columns: TableProps<ParsedPluginPolicy>["columns"] = [
+  const columns: TableProps<CustomPluginPolicy>["columns"] = [
     {
       title: "Row",
       key: "row",
@@ -105,7 +101,7 @@ export const PluginPolicyList: FC<Plugin> = (plugin) => {
     fetchPolicies(0);
   };
 
-  const handleDelete = ({ id, signature }: ParsedPluginPolicy) => {
+  const handleDelete = ({ id, signature }: CustomPluginPolicy) => {
     if (signature) {
       modalAPI.confirm({
         title: "Are you sure delete this policy?",
@@ -133,14 +129,6 @@ export const PluginPolicyList: FC<Plugin> = (plugin) => {
   };
 
   useEffect(() => fetchPolicies(0), [id, fetchPolicies]);
-
-  useEffect(() => {
-    getRecipeSpecification(id)
-      .then((schema) => {
-        setState((prevState) => ({ ...prevState, schema }));
-      })
-      .catch(() => {});
-  }, [id]);
 
   return (
     <>

--- a/src/components/PluginPolicyModal.tsx
+++ b/src/components/PluginPolicyModal.tsx
@@ -29,7 +29,6 @@ import {
   FeeType,
   PolicySchema,
 } from "proto/policy_pb";
-import { RecipeSchema } from "proto/recipe_specification_pb";
 import { Effect, RuleSchema, TargetSchema, TargetType } from "proto/rule_pb";
 import { FC, ReactNode, useEffect, useMemo, useState } from "react";
 import { useLocation } from "react-router-dom";
@@ -38,7 +37,7 @@ import { modalHash } from "utils/constants/core";
 import { toCapitalizeFirst, toTimestamp } from "utils/functions";
 import { signPluginPolicy } from "utils/services/extension";
 import { addPluginPolicy } from "utils/services/marketplace";
-import { Configuration, Plugin, PluginPolicy } from "utils/types";
+import { CustomRecipeSchema, Plugin, PluginPolicy } from "utils/types";
 import { v4 as uuidv4 } from "uuid";
 
 type FieldType = {
@@ -53,9 +52,7 @@ type FieldType = {
 interface PluginPolicyModalProps {
   onFinish: () => void;
   plugin: Plugin;
-  schema: Omit<RecipeSchema, "configuration"> & {
-    configuration?: Configuration;
-  };
+  schema: CustomRecipeSchema;
 }
 
 interface InitialState {

--- a/src/pages/plugin_details/index.tsx
+++ b/src/pages/plugin_details/index.tsx
@@ -22,21 +22,23 @@ import { toNumeralFormat } from "utils/functions";
 import { startReshareSession } from "utils/services/extension";
 import {
   getPlugin,
+  getRecipeSpecification,
   isPluginInstalled,
   uninstallPlugin,
 } from "utils/services/marketplace";
-import { Plugin } from "utils/types";
+import { CustomRecipeSchema, Plugin } from "utils/types";
 
 interface InitialState {
   isInstalled?: boolean;
   loading?: boolean;
   plugin?: Plugin;
+  schema?: CustomRecipeSchema;
 }
 
 export const PluginDetailsPage = () => {
   const initialState: InitialState = {};
   const [state, setState] = useState(initialState);
-  const { isInstalled, loading, plugin } = state;
+  const { isInstalled, loading, plugin, schema } = state;
   const { id = "" } = useParams<{ id: string }>();
   const { connect, isConnected } = useApp();
   const [messageApi, messageHolder] = message.useMessage();
@@ -98,6 +100,16 @@ export const PluginDetailsPage = () => {
   useEffect(() => {
     if (isInstalled === false) checkStatus();
   }, [checkStatus, isInstalled]);
+
+  useEffect(() => {
+    if (isInstalled) {
+      getRecipeSpecification(id)
+        .then((schema) => {
+          setState((prevState) => ({ ...prevState, schema }));
+        })
+        .catch(() => {});
+    }
+  }, [id, isInstalled]);
 
   useEffect(() => {
     if (isConnected) {
@@ -290,13 +302,13 @@ export const PluginDetailsPage = () => {
                       ) : isInstalled ? (
                         <>
                           <Button
-                            disabled={loading}
+                            disabled={loading || !schema}
                             kind="primary"
                             onClick={() =>
                               navigate(modalHash.policy, { state: true })
                             }
                           >
-                            Add recipeint
+                            Add recipient
                           </Button>
                           <Button
                             loading={loading}
@@ -343,7 +355,7 @@ export const PluginDetailsPage = () => {
               schedule, and manage payroll so you can focus on building while
               your contributors get paid on time.
             </Stack>
-            <PluginPolicyList {...plugin} />
+            <PluginPolicyList plugin={plugin} schema={schema} />
             <PluginReviewList
               isInstalled={isInstalled}
               onInstall={handleInstall}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,4 +1,6 @@
 import type * as CSS from "csstype";
+import { Policy } from "proto/policy_pb";
+import { RecipeSchema } from "proto/recipe_specification_pb";
 
 export type AuthTokenForm = {
   chainCodeHex: string;
@@ -22,6 +24,12 @@ export type Configuration = {
   properties: Record<string, Property>;
   required: string[];
   type: "object";
+};
+
+export type CustomPluginPolicy = PluginPolicy & { parsedRecipe: Policy };
+
+export type CustomRecipeSchema = Omit<RecipeSchema, "configuration"> & {
+  configuration?: Configuration;
 };
 
 export type Plugin = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Plugin details now loads and uses a recipe schema, enabling schema‑driven policy management.
  - “Add recipient” is enabled only after schema loads, improving guidance and preventing premature actions.
- Bug Fixes
  - Disabled buttons no longer trigger click actions.
  - Corrected UI text from “Add recipeint” to “Add recipient.”
- Refactor
  - Policy list and modal now receive schema externally, simplifying data flow and ensuring the UI renders schema-dependent elements only when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->