### PR TITLE
⚡️ Make fees hardcoded values on the frontend

### DIFF
--- a/src/pages/app_policy/index.tsx
+++ b/src/pages/app_policy/index.tsx
@@ -82,29 +82,8 @@ export const AppPolicyPage = () => {
   const colors = useTheme();
 
   const isFeesPlugin = useMemo(() => {
-    return schema?.pluginId === "vultisig-fees-feee";
-  }, [schema]);
-
-  useEffect(() => {
-    if (isFeesPlugin) {
-      form.setFieldValue("rules", [{
-        resource: "ethereum.erc20.transfer",
-        target: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-        amount: "500000000",
-        recipient: "1",
-      }]);
-    }
-  }, [isFeesPlugin]);
-
-  const ruleInitValues = useMemo(() => {
-    return {
-      ...(isFeesPlugin && {
-        amount: "500000000", // Fee Max
-        recipient: "1", // Vultisig Treasury
-        token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
-      }),
-    };
-  }, [isFeesPlugin]);
+    return appId === import.meta.env.VITE_FEE_PLUGIN_ID;
+  }, [appId]);
 
   const handleBack = useCallback(() => {
     goBack(routeTree.appDetails.link(appId));
@@ -446,6 +425,23 @@ export const AppPolicyPage = () => {
                 form={form}
                 layout="vertical"
                 onFinish={onFinishSuccess}
+                initialValues={
+                  isFeesPlugin
+                    ? {
+                        maxTxsPerWindow: 2,
+                        rateLimitWindow: 2,
+                        rules: [
+                          {
+                            resource: "ethereum.erc20.transfer",
+                            target:
+                              "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                            amount: "500000000",
+                            recipient: "1",
+                          },
+                        ],
+                      }
+                    : {}
+                }
               >
                 {!!schema?.configuration?.properties && (
                   <Stack $style={{ display: step === 0 ? "block" : "none" }}>
@@ -643,7 +639,7 @@ export const AppPolicyPage = () => {
                                             name={[name, "target"]}
                                             rules={[{ required: true }]}
                                           >
-                                            <Input disabled={isFeesPlugin}  />
+                                            <Input disabled={isFeesPlugin} />
                                           </Form.Item>
                                         )}
                                       </>
@@ -747,7 +743,10 @@ export const AppPolicyPage = () => {
                               <Form.ErrorList errors={errors} />
                             </Stack>
                           )}
-                          <Button onClick={() => add(ruleInitValues)}>
+                          <Button
+                            disabled={isFeesPlugin}
+                            onClick={() => add({})}
+                          >
                             Add rule
                           </Button>
                         </VStack>
@@ -776,13 +775,13 @@ export const AppPolicyPage = () => {
                         name="maxTxsPerWindow"
                         label="Max Txs Per Window"
                       >
-                        <InputNumber disabled={isFeesPlugin} min={1} defaultValue={isFeesPlugin ? 2 : undefined} />
+                        <InputNumber disabled={isFeesPlugin} min={1} />
                       </Form.Item>
                       <Form.Item<FormFieldType>
                         name="rateLimitWindow"
                         label="Rate Limit Window (seconds)"
                       >
-                        <InputNumber disabled={isFeesPlugin} min={1} defaultValue={isFeesPlugin ? 2 : undefined} />
+                        <InputNumber disabled={isFeesPlugin} min={1} />
                       </Form.Item>
                     </Stack>
                   </Stack>

--- a/src/pages/app_policy/index.tsx
+++ b/src/pages/app_policy/index.tsx
@@ -85,6 +85,17 @@ export const AppPolicyPage = () => {
     return schema?.pluginId === "vultisig-fees-feee";
   }, [schema]);
 
+  useEffect(() => {
+    if (isFeesPlugin) {
+      form.setFieldValue("rules", [{
+        resource: "ethereum.erc20.transfer",
+        target: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        amount: "500000000",
+        recipient: "1",
+      }]);
+    }
+  }, [isFeesPlugin]);
+
   const ruleInitValues = useMemo(() => {
     return {
       ...(isFeesPlugin && {
@@ -632,7 +643,7 @@ export const AppPolicyPage = () => {
                                             name={[name, "target"]}
                                             rules={[{ required: true }]}
                                           >
-                                            <Input />
+                                            <Input disabled={isFeesPlugin}  />
                                           </Form.Item>
                                         )}
                                       </>
@@ -765,13 +776,13 @@ export const AppPolicyPage = () => {
                         name="maxTxsPerWindow"
                         label="Max Txs Per Window"
                       >
-                        <InputNumber min={1} />
+                        <InputNumber disabled={isFeesPlugin} min={1} defaultValue={isFeesPlugin ? 2 : undefined} />
                       </Form.Item>
                       <Form.Item<FormFieldType>
                         name="rateLimitWindow"
                         label="Rate Limit Window (seconds)"
                       >
-                        <InputNumber min={1} />
+                        <InputNumber disabled={isFeesPlugin} min={1} defaultValue={isFeesPlugin ? 2 : undefined} />
                       </Form.Item>
                     </Stack>
                   </Stack>


### PR DESCRIPTION
Hardcode fee values on the frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When the fees plugin is enabled, the Rules form auto-populates with a default ERC‑20 transfer rule and scheduling defaults (Max Txs Per Window = 2, Rate Limit Window = 2).
  * The Target input and Resource selector in Rules are disabled when the fees plugin is enabled to prevent edits to the prefilled rule.
  * The "Add rule" action is disabled when the fees plugin is enabled to maintain the preset configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->