### PR TITLE
Rename plugin references to app

### DIFF
--- a/src/components/AppPolicies.tsx
+++ b/src/components/AppPolicies.tsx
@@ -157,7 +157,7 @@ export const AppPolicies: FC<{ app: App; schema: RecipeSchema }> = ({
     return schema.configuration?.definitions;
   }, [schema]);
 
-  const isFeesPlugin = useMemo(() => {
+  const isFeesApp = useMemo(() => {
     return id === import.meta.env.VITE_FEE_APP_ID;
   }, [id]);
 
@@ -515,7 +515,7 @@ export const AppPolicies: FC<{ app: App; schema: RecipeSchema }> = ({
 
       return (
         <DynamicFormItem
-          disabled={isFeesPlugin}
+          disabled={isFeesApp}
           key={key}
           label={camelCaseToTitle(key)}
           name={fullKey}
@@ -774,7 +774,7 @@ export const AppPolicies: FC<{ app: App; schema: RecipeSchema }> = ({
             >
               <Stack as="span">{title}</Stack>
               <Stack as="span" $style={{ color: colors.textTertiary.toHex() }}>
-                {`/ ${t("addPolicy")}`}
+                {`/ ${t("addAutomation")}`}
               </Stack>
             </HStack>
           </HStack>
@@ -846,7 +846,7 @@ export const AppPolicies: FC<{ app: App; schema: RecipeSchema }> = ({
             layout="vertical"
             onFinish={onFinishSuccess}
             initialValues={
-              isFeesPlugin
+              isFeesApp
                 ? {
                     maxTxsPerWindow: 2,
                     rateLimitWindow: 2,
@@ -909,7 +909,7 @@ export const AppPolicies: FC<{ app: App; schema: RecipeSchema }> = ({
                                   {...restField}
                                 >
                                   <Select
-                                    disabled={isFeesPlugin}
+                                    disabled={isFeesApp}
                                     options={schema.supportedResources.map(
                                       (resource) => ({
                                         label: resource.resourcePath?.full,
@@ -960,7 +960,7 @@ export const AppPolicies: FC<{ app: App; schema: RecipeSchema }> = ({
                                                 ]}
                                               >
                                                 <Input
-                                                  disabled={isFeesPlugin}
+                                                  disabled={isFeesApp}
                                                 />
                                               </Form.Item>
                                             )
@@ -972,7 +972,7 @@ export const AppPolicies: FC<{ app: App; schema: RecipeSchema }> = ({
                                             name={[name, "target"]}
                                             rules={[{ required: step > 0 }]}
                                           >
-                                            <Input disabled={isFeesPlugin} />
+                                            <Input disabled={isFeesApp} />
                                           </Form.Item>
                                         )}
                                         <Stack
@@ -1088,7 +1088,7 @@ export const AppPolicies: FC<{ app: App; schema: RecipeSchema }> = ({
                             </Stack>
                           )}
                           <Button
-                            disabled={isFeesPlugin}
+                            disabled={isFeesApp}
                             onClick={() => add({})}
                             kind="secondary"
                           >
@@ -1141,13 +1141,13 @@ export const AppPolicies: FC<{ app: App; schema: RecipeSchema }> = ({
                     name="maxTxsPerWindow"
                     label={t("maxTransactions")}
                   >
-                    <InputNumber disabled={isFeesPlugin} min={1} />
+                    <InputNumber disabled={isFeesApp} min={1} />
                   </Form.Item>
                   <Form.Item<FormFieldType>
                     name="rateLimitWindow"
                     label={`${t("rateLimit")} (${t("seconds")})`}
                   >
-                    <InputNumber disabled={isFeesPlugin} min={1} />
+                    <InputNumber disabled={isFeesApp} min={1} />
                   </Form.Item>
 
                   <Stack

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1,7 +1,7 @@
 export const en = {
   // A
   action: "Action",
-  addPolicy: "Add Policy",
+  addAutomation: "Add Automation",
   addRule: "Add Rule",
   appPermissions: "App Permissions",
   appStore: "App Store",
@@ -17,7 +17,7 @@ export const en = {
   confirmAppUninstallation: "Are you sure you want to uninstall this app?",
   confirmPolicyDeletion: "Are you sure you want to delete this policy?",
   connect: "Connect",
-  connectWallet: "Connect Wallet",
+  connectVault: "Connect Vault",
   continue: "Continue",
   createdBy: "Created By",
   currency: "Currency",
@@ -59,12 +59,12 @@ export const en = {
   paymentModal: {
     action: "Add to Vault",
     description:
-      "This plugin handles payments securely using your wallet, with full control over fees and visibility. This is a one-time setup.",
+      "This app handles payments securely using your wallet, with full control over fees and visibility. This is a one-time setup.",
     subtitle: "Required Standard App",
     title: "Payment App Required",
   },
   policies: "Policies",
-  policyMaxTxs: "This plugin can send up to {{count}} transactions",
+  policyMaxTxs: "This app can send up to {{count}} transactions",
   policyRateLimit: "every {{duration}}",
   postReview: "Post Review",
   // R

--- a/src/layouts/Default.tsx
+++ b/src/layouts/Default.tsx
@@ -111,7 +111,7 @@ export const DefaultLayout = () => {
           {
             icon: <LogInIcon />,
             key: "5",
-            label: t("connectWallet"),
+            label: t("connectVault"),
             onClick: connect,
           },
         ]),
@@ -282,7 +282,7 @@ export const DefaultLayout = () => {
                   maxWidth: "110px",
                 }}
               >
-                {vault?.name || t("connectWallet")}
+                {vault?.name || t("connectVault")}
               </Stack>
 
               <EllipsisVerticalIcon />

--- a/src/pages/AppDetails.tsx
+++ b/src/pages/AppDetails.tsx
@@ -401,7 +401,7 @@ export const AppDetailsPage = () => {
                                 disabled={loading || !schema}
                                 href={modalHash.policy}
                               >
-                                {t("addPolicy")}
+                                {t("addAutomation")}
                               </Button>
                             )}
                             <Button
@@ -706,7 +706,7 @@ export const AppDetailsPage = () => {
                     >
                       {item}
                     </Stack>
-                    <Tooltip title="Required to securely approve and route plugin payment transactions through your vault.">
+                    <Tooltip title="Required to securely approve and route app payment transactions through your vault.">
                       <CircleInfoIcon />
                     </Tooltip>
                   </HStack>

--- a/src/pages/Apps.tsx
+++ b/src/pages/Apps.tsx
@@ -29,9 +29,9 @@ export const AppsPage = () => {
   const { categories, loading, apps } = state;
   const { filters, setFilters } = useFilterParams<AppFilters>();
   const colors = useTheme();
-  const [newPlugin] = apps;
+  const [newApp] = apps;
 
-  const fetchPlugins = useCallback((skip: number, filters: AppFilters) => {
+  const fetchApps = useCallback((skip: number, filters: AppFilters) => {
     setState((prevState) => ({ ...prevState, loading: true }));
 
     getApps({ ...filters, skip })
@@ -43,14 +43,14 @@ export const AppsPage = () => {
       });
   }, []);
 
-  const debouncedFetchPlugins = useMemo(
-    () => debounce(fetchPlugins, 500),
-    [fetchPlugins]
+  const debouncedFetchApps = useMemo(
+    () => debounce(fetchApps, 500),
+    [fetchApps]
   );
 
   useEffect(
-    () => debouncedFetchPlugins(0, filters),
-    [debouncedFetchPlugins, filters]
+    () => debouncedFetchApps(0, filters),
+    [debouncedFetchApps, filters]
   );
 
   useEffect(() => {
@@ -150,7 +150,7 @@ export const AppsPage = () => {
             <Spin centered />
           ) : apps.length ? (
             <>
-              {!!newPlugin && (
+              {!!newApp && (
                 <VStack $style={{ flexDirection: "column", gap: "16px" }}>
                   <Stack
                     as="span"
@@ -158,7 +158,7 @@ export const AppsPage = () => {
                   >
                     {t("new")}
                   </Stack>
-                  <AppItem {...newPlugin} horizontal />
+                  <AppItem {...newApp} horizontal />
                 </VStack>
               )}
               <VStack $style={{ flexDirection: "column", gap: "16px" }}>

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -142,13 +142,13 @@ export const getApps = async ({
   return get<{ plugins: App[]; totalCount: number }>(`${storeApiUrl}/plugins`, {
     params: toSnakeCase({ categoryId, skip, sort, take, term }),
   }).then(({ plugins, totalCount }) => {
-    const modifiedPlugins: App[] =
+    const modifiedApps: App[] =
       plugins?.map((plugin) => ({
         ...plugin,
         pricing: plugin.pricing || [],
       })) || [];
 
-    return { apps: modifiedPlugins, totalCount };
+    return { apps: modifiedApps, totalCount };
   });
 };
 


### PR DESCRIPTION
## Description

Replace "Wallet" with "Vault" throughout the application
Replace "Plugins" with "Apps" throughout the application
Replace "Add Policy" with "Add Automation" in relevant contexts

Fixes [#212](https://github.com/vultisig/recipes/issues/212)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated UI terminology throughout the application: "plugin" now displays as "app," "policy" as "automation," and "wallet" as "vault."
  * Revised descriptive text and tooltips to reflect updated terminology for consistency across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->