### PR TITLE
Reset form fields after policy create

### DIFF
--- a/src/components/appPolicyForms/Default.tsx
+++ b/src/components/appPolicyForms/Default.tsx
@@ -295,6 +295,7 @@ export const DefaultPolicyForm: FC<DefaultPolicyFormProps> = ({
   useEffect(() => {
     if (!visible) return;
 
+    form.resetFields();
     setState((prevState) => ({
       ...prevState,
       isAdded: false,

--- a/src/components/appPolicyForms/RecurringSwaps.tsx
+++ b/src/components/appPolicyForms/RecurringSwaps.tsx
@@ -146,6 +146,7 @@ export const RecurringSwapsPolicyForm: FC<DefaultPolicyFormProps> = ({
   useEffect(() => {
     if (!visible) return;
 
+    form.resetFields();
     setState({ isAdded: false, loading: false, step: 1 });
   }, [form, visible]);
 


### PR DESCRIPTION
## Description

Currently, the form for policy creation doesnt reset after a successful policy creation. If the user tries to create a second policy after the first one using "Create your own automations" the values from the previous policy creation will still be there. This will cause the fromAddress to not update, which will result in /suggest and subsequently /policy to fail. This PR resets the form fields after every successful submit or when the modal closes

To recreate error:
1. Create policy and submit
2. Wait for success. Without refreshing the page, click "Add Automations" again and select "Create your own automations" params from previous policy will still be there
3. Fill in params and click submit, if chain is not modified at all the policy creation will fail

<img width="515" height="133" alt="image" src="https://github.com/user-attachments/assets/3937ec32-c169-4813-a5fd-88ea4ec744d3" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Policy forms now properly reset all fields when opened, ensuring previously entered data is cleared and users start with a clean form state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->