### PR TITLE
Refactor recurring swaps form and add date checkbox item

### DIFF
--- a/src/components/appPolicyForms/components/DateCheckboxFormItem.tsx
+++ b/src/components/appPolicyForms/components/DateCheckboxFormItem.tsx
@@ -1,0 +1,77 @@
+import { Checkbox, Form, FormItemProps, Input } from "antd";
+import dayjs from "dayjs";
+import { FC, useEffect } from "react";
+
+import { Frequency } from "@/utils/frequencies";
+
+export const DateCheckboxFormItem: FC<
+  FormItemProps & { disabled?: boolean }
+> = ({ disabled, name, ...rest }) => {
+  const checkboxName = `${name}Status`;
+  const form = Form.useFormInstance();
+  const frequency = Form.useWatch<Frequency>("frequency", form);
+  const isActive = Form.useWatch<boolean>(checkboxName, form);
+
+  useEffect(() => {
+    const now = dayjs().add(1, "minute").startOf("minute");
+
+    if (isActive) {
+      form.setFieldValue(name, now.utc().format());
+    } else {
+      switch (frequency) {
+        case "hourly": {
+          form.setFieldValue(
+            name,
+            now.add(1, "hour").startOf("hour").utc().format()
+          );
+          break;
+        }
+        case "daily": {
+          form.setFieldValue(
+            name,
+            now.add(1, "day").startOf("day").utc().format()
+          );
+          break;
+        }
+        case "weekly": {
+          form.setFieldValue(
+            name,
+            now.add(1, "week").startOf("week").utc().format()
+          );
+          break;
+        }
+        case "bi-weekly": {
+          form.setFieldValue(
+            name,
+            now.add(2, "week").startOf("week").utc().format()
+          );
+          break;
+        }
+        case "monthly": {
+          form.setFieldValue(
+            name,
+            now.add(1, "month").startOf("month").utc().format()
+          );
+          break;
+        }
+        default: {
+          form.setFieldValue(name, now.utc().format());
+          break;
+        }
+      }
+    }
+  }, [form, isActive, name, frequency]);
+
+  return (
+    <>
+      <Form.Item name={checkboxName} valuePropName="checked" {...rest}>
+        <Checkbox disabled={disabled}>
+          Start first Recurring Swap after setup
+        </Checkbox>
+      </Form.Item>
+      <Form.Item name={name} {...rest} noStyle>
+        <Input type="hidden" />
+      </Form.Item>
+    </>
+  );
+};

--- a/src/utils/frequencies.ts
+++ b/src/utils/frequencies.ts
@@ -1,0 +1,11 @@
+export const frequencies = [
+  "one-time",
+  "minutely",
+  "hourly",
+  "daily",
+  "weekly",
+  "bi-weekly",
+  "monthly",
+] as const;
+
+export type Frequency = (typeof frequencies)[number];


### PR DESCRIPTION
* Added a new `DateCheckboxFormItem` component to allow users to choose whether the first recurring swap starts immediately after setup or at a calculated future date based on the selected frequency. 
* Frequency Handling Improvements:
* UI/UX Refinements

- Fix https://github.com/vultisig/recipes/issues/357

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added checkbox option to automatically start first Recurring Swap after setup

* **Improvements**
  * Enhanced cancel confirmation modal with centered layout
  * Updated date format display (YYYY-MM-DD HH:mm) in recurring swap preview
  * Improved form field validation and step progression logic

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->