### PR TITLE
Fix trial duration calculation in FreeTrialBanner

### DIFF
--- a/src/components/FreeTrialBanner.tsx
+++ b/src/components/FreeTrialBanner.tsx
@@ -15,7 +15,8 @@ export const FreeTrialBanner = () => {
   const trialRemaining = useMemo(() => {
     if (!feeAppStatus) return "";
 
-    const d = dayjs.duration(feeAppStatus.trialRemaining);
+    // Convert nanoseconds to milliseconds for dayjs
+    const d = dayjs.duration(feeAppStatus.trialRemaining / 1_000_000);
 
     let message = "";
 


### PR DESCRIPTION
This pull request makes a minor update to the `FreeTrialBanner` component to correctly handle the trial remaining time value. The change ensures that the duration is calculated in milliseconds instead of nanoseconds, which fixes the display of the remaining trial period.

* Updated `FreeTrialBanner` to convert `trialRemaining` from nanoseconds to milliseconds before passing it to `dayjs.duration`, ensuring accurate time calculations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed trial remaining time calculation to accurately display the correct number of days remaining in the free trial period.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->