### PR TITLE
Add VULT token to default tokens

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -314,7 +314,7 @@ export const getOneInchTokens = async (chain: EvmChain): Promise<Token[]> => {
     tokens: Record<string, OneInchToken>;
   }>(`${vultiApiUrl}/1inch/swap/v6.0/${evmChainInfo[chain].id}/tokens`);
 
-  return Object.values(tokens).map((token) => ({
+  const tokenList = Object.values(tokens).map((token) => ({
     chain,
     decimals: token.decimals,
     id: token.address,


### PR DESCRIPTION
This pull request updates the token retrieval logic for the Ethereum chain in the `src/utils/api.ts` file. The main change is the addition of the VULT token to the token list returned by the `getOneInchTokens` function for Ethereum. Additionally, it imports the `evmChains` object to support this logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VULT token is now available for selection on the Ethereum network.
  * VULT will appear in token lists used for swaps and token selection flows where Ethereum tokens are shown.
  * No changes to public interfaces or signatures were introduced.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->