### PR TITLE
Remove early-stage warning banner

### DIFF
--- a/src/layouts/Default.tsx
+++ b/src/layouts/Default.tsx
@@ -172,18 +172,6 @@ export const DefaultLayout = () => {
           zIndex: "2",
         }}
       >
-        <VStack
-          $style={{
-            alignItems: "center",
-            backgroundColor: colors.bgAlert.toHex(),
-            height: "40px",
-            justifyContent: "center",
-            width: "100%",
-          }}
-        >
-          This is an early-stage version of the platform. Do not rely on it for
-          production use or real funds. Testing only.
-        </VStack>
         <HStack
           $style={{
             alignItems: "center",


### PR DESCRIPTION
## Summary
- Removes the early-stage warning banner from the header layout
- The platform is ready for production use, so the testing-only warning is no longer needed

Closes #163

## Test plan
- [ ] Verify the banner no longer appears in the header
- [ ] Verify the header layout looks correct without the banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the early-stage platform announcement banner from the header. The header navigation and layout structure remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->