### PR TITLE
Update Polygon ticker from MATIC to POL

### DIFF
--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -143,7 +143,7 @@ const tickers: Record<Chain, string> = {
   [chains.Optimism]: "OP",
   [chains.Osmosis]: "OSMO",
   [chains.Polkadot]: "DOT",
-  [chains.Polygon]: "MATIC",
+  [chains.Polygon]: "POL",
   [chains.Ripple]: "XRP",
   [chains.Solana]: "SOL",
   [chains.Sei]: "SEI",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Polygon network's native token ticker symbol to align with current network standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->